### PR TITLE
Restoring learning observer components to requirements.txt.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ dash-table
 faker
 filetype
 git+https://github.com/pmitros/tsvx.git@09bf7f33107f66413d929075a8b54c36ca581dae#egg=tsvx
+git+https://github.com/ArgLab/learning_observer_dash_components
 git+https://github.com/testlabauto/loremipsum.git@b7bd71a6651207ef88993045cd755f20747f2a1e#egg=loremipsum
 google-auth
 ipython


### PR DESCRIPTION
The Learning Observer Components have been removed from the requirements.txt  That dependency is necessary to support the dash integration use of LOConnect.  This restores that.  